### PR TITLE
Fix excessive CPU usage when using `run_every`

### DIFF
--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -2191,7 +2191,7 @@ static size_t fio_poll(void) {
 
   const struct timespec timeout = {
       .tv_sec = (timeout_millisec / 1000),
-      .tv_nsec = ((timeout_millisec & (~1023UL)) * 1000000)};
+      .tv_nsec = ((timeout_millisec % 1000) * 1000000)};
   /* wait for events and handle them */
   int active_count =
       kevent(evio_fd, NULL, 0, events, FIO_POLL_MAX_EVENTS, &timeout);


### PR DESCRIPTION
Because of the incorrect calculation of the `tv_nsec` value, `Iodine.run_every` currently causes excessive CPU usage with any timeout except 1s on kqueue systems.

I wonder what `& (~1023UL)` means, but if it is supposed to be a faster alternative to `% 1000`, then it doesn't seem to be working correctly.