### PR TITLE
File server updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Please notice that this change log contains changes for upcoming releases as wel
 
 ## Changes:
 
+#### Change log v.3.3.0 (2024-08-18)
+
+**Update**: Improvements and fixes for the static file service.
+
 #### Change log v.3.2.0 (2024-07-15)
 
 **Update**: Explicitly undefine the alloc function on IodineObjectStorage.

--- a/ext/iodine/http.c
+++ b/ext/iodine/http.c
@@ -470,13 +470,8 @@ found_file:
   /* set cache-control */
   http_set_header(h, HTTP_HEADER_CACHE_CONTROL, fiobj_dup(HTTP_HVALUE_MAX_AGE));
   /* set & test etag */
-  uint64_t etag = (uint64_t)file_data.st_size;
-  etag ^= (uint64_t)file_data.st_mtime;
-  etag = fiobj_hash_string(&etag, sizeof(uint64_t));
-  FIOBJ etag_str = fiobj_str_buf(32);
-  fiobj_str_resize(etag_str,
-                   fio_base64_encode(fiobj_obj2cstr(etag_str).data,
-                                     (void *)&etag, sizeof(uint64_t)));
+  FIOBJ etag_str = fiobj_str_buf(1);
+  fiobj_str_printf(etag_str, "%lx-%llx", file_data.st_mtime, file_data.st_size);
   /* set */
   http_set_header(h, HTTP_HEADER_ETAG, etag_str);
   /* test */

--- a/ext/iodine/http.c
+++ b/ext/iodine/http.c
@@ -499,7 +499,7 @@ found_file:
     if (!ifrange_hash)
       ifrange_hash = fiobj_hash_string("if-range", 8);
     FIOBJ tmp = fiobj_hash_get2(h->headers, ifrange_hash);
-    if (tmp && fiobj_iseq(tmp, etag_str)) {
+    if (tmp && !fiobj_iseq(tmp, etag_str)) {
       fiobj_hash_delete2(h->headers, range_hash);
     } else {
       tmp = fiobj_hash_get2(h->headers, range_hash);

--- a/ext/iodine/http.c
+++ b/ext/iodine/http.c
@@ -524,7 +524,7 @@ found_file:
         /* we ignore multimple ranges, only responding with the first range. */
         if (start_at < 0) {
           if (0 - start_at < file_data.st_size) {
-            offset = file_data.st_size - start_at;
+            offset = file_data.st_size + start_at;
             length = 0 - start_at;
           }
         } else if (end_at) {

--- a/lib/iodine/version.rb
+++ b/lib/iodine/version.rb
@@ -1,3 +1,3 @@
 module Iodine
-  VERSION = '3.2.0'.freeze
+  VERSION = '3.3.0'.freeze
 end


### PR DESCRIPTION
* Change the way etags are generated to ensure they do not change with server restart.
* Correctly compare `If-Range` headers.
* Support `Last-Modified` value in `If-Range`.
* Fix overflow issues with incorrect `Range` values.
* Render `416` for incorrect ranges.