### PR TITLE
Ensure we do not close FDs that are coming from Ruby

### DIFF
--- a/ext/iodine/fio.c
+++ b/ext/iodine/fio.c
@@ -363,6 +363,8 @@ typedef struct {
   uint8_t open;
   /** indicated that the connection should be closed. */
   uint8_t close;
+  /** indicates whether the fd is coming from the Fiber Scheduler. */
+  uint8_t internal;
   /** peer address length */
   uint8_t addr_len;
   /** peer address */
@@ -2226,8 +2228,11 @@ static size_t fio_poll(void) {
                             NULL);
       }
       if (events[i].flags & (EV_EOF | EV_ERROR)) {
-        fio_defer_push_task(deferred_force_close_in_poll,
-                            (void *)fd2uuid(events[i].udata), NULL);
+        if(fd_data(events[i].udata).internal) {
+          fio_force_close_in_poll(fd2uuid(events[i].udata));
+        } else {
+          fio_clear_fd((intptr_t)events[i].udata, 0);
+        }
       }
     }
   } else if (active_count < 0) {
@@ -4033,6 +4038,7 @@ static int fio_attach__internal(void *uuid_, void *protocol_) {
   }
   fio_protocol_s *old_pr = uuid_data(uuid).protocol;
   uuid_data(uuid).open = 1;
+  uuid_data(uuid).internal = 1;
   uuid_data(uuid).protocol = protocol;
   touchfd(fio_uuid2fd(uuid));
   fio_unlock(&uuid_data(uuid).protocol_lock);
@@ -4093,6 +4099,7 @@ static int fio_watch__internal(void *uuid_, void *protocol_) {
 
   fio_protocol_s *old_pr = uuid_data(uuid).protocol;
   uuid_data(uuid).open = 1;
+  uuid_data(uuid).internal = 0;
   uuid_data(uuid).protocol = protocol;
   touchfd(fio_uuid2fd(uuid));
   fio_unlock(&uuid_data(uuid).protocol_lock);

--- a/ext/iodine/scheduler.c
+++ b/ext/iodine/scheduler.c
@@ -15,7 +15,8 @@
 static ID call_id;
 static uint8_t ATTACH_ON_READ_READY_CALLBACK;
 static uint8_t ATTACH_ON_WRITE_READY_CALLBACK;
-static VALUE timeout_args[1];
+static VALUE e_timeout_args[1];
+static VALUE e_badf_args[1];
 
 /* *****************************************************************************
 Fiber Scheduler API
@@ -35,6 +36,10 @@ typedef struct {
 
 static void iodine_scheduler_task_close(intptr_t uuid, fio_protocol_s *fio_protocol) {
   scheduler_protocol_s *protocol = (scheduler_protocol_s *)fio_protocol;
+
+  if (!protocol->fulfilled) {
+    IodineCaller.call2(protocol->block, call_id, 1, e_badf_args);
+  }
 
   IodineStore.remove(protocol->block);
   fio_free(protocol);
@@ -57,7 +62,7 @@ static void iodine_scheduler_task_timeout(intptr_t uuid, fio_protocol_s *fio_pro
   scheduler_protocol_s *protocol = (scheduler_protocol_s *)fio_protocol;
 
   if (!protocol->fulfilled) {
-    IodineCaller.call2(protocol->block, call_id, 1, timeout_args);
+    IodineCaller.call2(protocol->block, call_id, 1, e_timeout_args);
     protocol->fulfilled = 1;
   }
 }
@@ -178,7 +183,8 @@ Scheduler initialization
 
 void iodine_scheduler_initialize(void) {
   call_id = rb_intern2("call", 4);
-  timeout_args[0] = UINT2NUM(ETIMEDOUT);
+  e_timeout_args[0] = INT2NUM(-ETIMEDOUT);
+  e_badf_args[0] = INT2NUM(-EBADF);
 
   VALUE SchedulerModule = rb_define_module_under(IodineModule, "Scheduler");
 

--- a/ext/iodine/scheduler.c
+++ b/ext/iodine/scheduler.c
@@ -16,7 +16,7 @@ static ID call_id;
 static uint8_t ATTACH_ON_READ_READY_CALLBACK;
 static uint8_t ATTACH_ON_WRITE_READY_CALLBACK;
 static VALUE e_timeout_args[1];
-static VALUE e_badf_args[1];
+static VALUE e_closed_args[1];
 
 /* *****************************************************************************
 Fiber Scheduler API
@@ -38,7 +38,7 @@ static void iodine_scheduler_task_close(intptr_t uuid, fio_protocol_s *fio_proto
   scheduler_protocol_s *protocol = (scheduler_protocol_s *)fio_protocol;
 
   if (!protocol->fulfilled) {
-    IodineCaller.call2(protocol->block, call_id, 1, e_badf_args);
+    IodineCaller.call2(protocol->block, call_id, 1, e_closed_args);
   }
 
   IodineStore.remove(protocol->block);
@@ -184,7 +184,7 @@ Scheduler initialization
 void iodine_scheduler_initialize(void) {
   call_id = rb_intern2("call", 4);
   e_timeout_args[0] = INT2NUM(-ETIMEDOUT);
-  e_badf_args[0] = INT2NUM(-EBADF);
+  e_closed_args[0] = INT2NUM(-EIO);
 
   VALUE SchedulerModule = rb_define_module_under(IodineModule, "Scheduler");
 

--- a/lib/iodine/version.rb
+++ b/lib/iodine/version.rb
@@ -1,3 +1,3 @@
 module Iodine
-  VERSION = '3.3.0'.freeze
+  VERSION = '4.0.0'.freeze
 end


### PR DESCRIPTION
This ensures file descriptors that are coming from the Fiber Scheduler are not being closed.