### PR TITLE
Phase 1: HTTP/1.1 streaming transport primitive (chunked transfer encoding)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,8 @@ task :spec => [:compile, :rspec]
 
 task :default => [:compile, :spec]
 
-Rake::ExtensionTask.new "iodine" do |ext|
+Rake::ExtensionTask.new "iodine_ext" do |ext|
+  ext.ext_dir = "ext/iodine" 
   ext.lib_dir = "lib/iodine"
 end
 

--- a/ext/iodine/http.c
+++ b/ext/iodine/http.c
@@ -345,6 +345,21 @@ int http_send_body(http_s *r, void *data, uintptr_t length) {
       ->http_send_body(r, data, length);
 }
 /**
+ * Streams a chunk of the response body (chunked transfer encoding).
+ *
+ * Unlike `http_send_body`, the `http_s` handle remains valid for further
+ * streaming and MUST be finalized with `http_finish`.
+ *
+ * Returns -1 on error and 0 on success.
+ */
+int http_stream(http_s *r, void *data, uintptr_t length) {
+  if (HTTP_INVALID_HANDLE(r))
+    return -1;
+  /* No add_content_length: a stream has no fixed length. */
+  add_date(r);
+  return ((http_vtable_s *)r->private_data.vtbl)->http_stream(r, data, length);
+}
+/**
  * Sends the response headers and the specified file (the response's body).
  *
  * Returns -1 on error and 0 on success.

--- a/ext/iodine/http.h
+++ b/ext/iodine/http.h
@@ -209,6 +209,21 @@ int http_set_cookie(http_s *h, http_cookie_args_s);
 int http_send_body(http_s *h, void *data, uintptr_t length);
 
 /**
+ * Streams a chunk of the response body using chunked transfer encoding.
+ *
+ * Unlike `http_send_body`, this may be called repeatedly: each call sends one
+ * chunk, and the headers are sent automatically on the first call.
+ *
+ * The data is *copied*; the caller still owns its memory.
+ *
+ * The `http_s` handle REMAINS VALID across calls and MUST be finalized with
+ * `http_finish`, which sends the terminating zero-length chunk.
+ *
+ * Returns -1 on error and 0 on success.
+ */
+int http_stream(http_s *h, void *data, uintptr_t length);
+
+/**
  * Sends the response headers and the specified file (the response's body).
  *
  * The file is closed automatically.

--- a/ext/iodine/http1.c
+++ b/ext/iodine/http1.c
@@ -28,6 +28,7 @@ typedef struct http1pr_s {
   uint8_t close;
   uint8_t is_client;
   uint8_t stop;
+  http_stream_state_e stream_state;
   uint8_t buf[];
 } http1pr_s;
 
@@ -221,6 +222,16 @@ static int http1_sendfile(http_s *h, int fd, uintptr_t length,
 
 /** Should send existing headers or complete streaming */
 static void htt1p_finish(http_s *h) {
+  http1pr_s *p = handle2pr(h);
+
+  /* An active chunked stream ends with the terminating zero-length chunk */
+  if (p->stream_state == HTTP_STREAM_ACTIVE) {
+    fiobj_send_free(p->p.uuid, fiobj_str_new("0\r\n\r\n", 5));
+    p->stream_state = HTTP_STREAM_CLOSED;
+    http1_after_finish(h);
+    return;
+  }
+
   FIOBJ packet = headers2str(h, 0);
   if (packet)
     fiobj_send_free((handle2pr(h)->p.uuid), packet);
@@ -229,6 +240,38 @@ static void htt1p_finish(http_s *h) {
   }
   http1_after_finish(h);
 }
+
+/** Sends a single chunk of a streaming HTTP/1.1 response (chunked encoding). */
+static int http1_stream(http_s *h, void *data, uintptr_t length) {
+  http1pr_s *p = handle2pr(h);
+  const intptr_t uuid = p->p.uuid;
+
+  if (p->stream_state == HTTP_STREAM_IDLE) {
+    FIOBJ te_key = fiobj_str_new("transfer-encoding", 17);
+    http_set_header(h, te_key, fiobj_str_new("chunked", 7));
+    fiobj_free(te_key);
+
+    FIOBJ headers = headers2str(h, 0);
+    if (!headers) {
+      http1_after_finish(h);
+      return -1;
+    }
+    fiobj_send_free(uuid, headers);
+    p->stream_state = HTTP_STREAM_ACTIVE;
+  }
+
+  if (length == 0)
+    return 0;
+
+  FIOBJ packet = fiobj_str_buf(length + 32);
+  fiobj_str_printf(packet, "%lx\r\n", (unsigned long)length);
+  fiobj_str_write(packet, data, length);
+  fiobj_str_write(packet, "\r\n", 2);
+  fiobj_send_free(uuid, packet);
+
+  return 0;
+}
+
 /** Push for data - unsupported. */
 static int http1_push_data(http_s *h, void *data, uintptr_t length,
                            FIOBJ mime_type) {
@@ -534,6 +577,7 @@ Virtual Table Decleration
 struct http_vtable_s HTTP1_VTABLE = {
     .http_send_body = http1_send_body,
     .http_sendfile = http1_sendfile,
+    .http_stream = http1_stream,
     .http_finish = htt1p_finish,
     .http_push_data = http1_push_data,
     .http_push_file = http1_push_file,

--- a/ext/iodine/http_internal.h
+++ b/ext/iodine/http_internal.h
@@ -30,6 +30,13 @@ Types
 typedef struct http_fio_protocol_s http_fio_protocol_s;
 typedef struct http_vtable_s http_vtable_s;
 
+/* HTTP/1.1 response streaming lifecycle (Phase 1: transport only). */
+typedef enum {
+  HTTP_STREAM_IDLE = 0, /* default: no stream started, headers not yet sent */
+  HTTP_STREAM_ACTIVE,   /* headers sent; chunked body in progress */
+  HTTP_STREAM_CLOSED,   /* terminating 0-length chunk sent; stream complete */
+} http_stream_state_e;
+
 struct http_vtable_s {
   /** Should send existing headers and data */
   int (*const http_send_body)(http_s *h, void *data, uintptr_t length);

--- a/spec/support/iodine_server.rb
+++ b/spec/support/iodine_server.rb
@@ -8,12 +8,12 @@ module Spec
         HTTP.timeout(1)
       end
 
-      def http_get(path, *args)
-        http_client.get("http://localhost:#{server_port}#{path}", *args)
+      def http_get(path, *args, **kwargs)
+        http_client.get("http://localhost:#{server_port}#{path}", *args, **kwargs)
       end
 
-      def http_post(path, *args)
-        http_client.post("http://localhost:#{server_port}#{path}", *args)
+      def http_post(path, *args, **kwargs)
+        http_client.post("http://localhost:#{server_port}#{path}", *args, **kwargs)
       end
 
       def spawn_with_test_log(cmd, verbose: ENV.key?('VERBOSE'))


### PR DESCRIPTION
### Summary
First phase of HTTP streaming support for Rage. Adds the Iodine transport primitive that sends an HTTP/1.1 response body incrementally via chunked transfer encoding, instead of buffering the whole body first. Scoped to the C transport layer only.

### What it does
Fills the previously-unimplemented `http_stream` vtable slot with a `write → write → finish` lifecycle:
- `http_stream(h, data, length)`: sends one chunk. The first call also emits headers with `Transfer-Encoding: chunked`; the handle stays valid across calls (unlike `http_send_body`).
- `http_finish(h)`: ends the stream with the terminating `0\r\n\r\n` chunk.

Each chunk is framed as `<hex-length>\r\n<data>\r\n` per RFC 7230.

### Design
- Protocol-agnostic seam: generic `http_stream()` in `http.c` dispatches through the vtable and skips `Content-Length`. The chunked framing and `Transfer-Encoding` header live in the HTTP/1.1 plug (`http1_stream`), so a future HTTP/2 backend can fill the same slot with no app-facing change.
- State (`IDLE → ACTIVE → CLOSED`) lives on the existing `http1pr_s`, with `IDLE = 0` so new connections are correct by default. `http_finish` sends the terminator only for active streams, leaving header-only responses and SSE untouched.
- Existing String/`each` body paths, SSE, and WebSocket upgrades are unmodified.

### Changes
- `ext/iodine/http_internal.h`: `http_stream_state_e` enum.
- `ext/iodine/http1.c`: `stream_state` field on `http1pr_s`; `http1_stream` registered in `HTTP1_VTABLE`; `htt1p_finish` terminator.
- `ext/iodine/http.h` / `http.c`: public `http_stream()` declaration and generic implementation.

### Preliminary fixes (included)
<img width="1057" height="188" alt="Screenshot 2026-06-11 at 3 14 43 PM" src="https://github.com/user-attachments/assets/036650bf-afd2-4f2e-b459-b6005f6b8f20" />

- `Rakefile`: fix rake-compiler name mismatch (task was `iodine`, target is `iodine_ext`), which broke `rake compile` with `Errno::ENOENT`.

<img width="1436" height="460" alt="Screenshot 2026-06-11 at 3 44 00 PM" src="https://github.com/user-attachments/assets/d334b869-d02c-4b42-a2fc-9524ede9c443" />

- `spec/support/iodine_server.rb`: forward `**kwargs` in `http_get`/`http_post` so they work with `http` gem 6.x under Ruby 3 (was failing ~20 tests with an arity error).